### PR TITLE
[#6] Google OAuth 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,11 @@ dependencies {
 	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	// implementation 'com.google.cloud:spring-cloud-gcp-starter'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'
 
@@ -49,6 +53,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	// testImplementation 'org.springframework.security:spring-security-test'
+
+	testCompileOnly(group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2')
 }
 
 dependencyManagement {

--- a/src/main/java/com/yoonNeun/MyDreamPartner/common/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/common/security/provider/JwtTokenProvider.java
@@ -1,0 +1,63 @@
+package com.yoonNeun.MyDreamPartner.common.security.provider;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+import io.jsonwebtoken.io.Decoders;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret.key}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateToken(String subject, Date expiredDate) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(expiredDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractSubject(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/AuthToken.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/AuthToken.java
@@ -1,0 +1,23 @@
+package com.yoonNeun.MyDreamPartner.domain.oauth.domain;
+
+import lombok.Getter;
+
+@Getter
+public class AuthToken {
+
+    private final String accessToken;
+    private final String refreshToken;
+    private final String grantType;
+    private final Long expiresIn;
+
+    public AuthToken(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.grantType = grantType;
+        this.expiresIn = expiresIn;
+    }
+
+    public static AuthToken of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthToken(accessToken, refreshToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/AuthTokenGenerator.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/AuthTokenGenerator.java
@@ -1,0 +1,34 @@
+package com.yoonNeun.MyDreamPartner.domain.oauth.domain;
+
+import com.yoonNeun.MyDreamPartner.common.security.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokenGenerator {
+
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthToken generate(Integer userId) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredDate = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredDate = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        String subject = userId.toString();
+        String accessToken = jwtTokenProvider.generateToken(subject, accessTokenExpiredDate);
+        String refreshToken = jwtTokenProvider.generateToken(subject, refreshTokenExpiredDate);
+
+        return AuthToken.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+
+    public Long extractUserId(String accessToken) {
+        return Long.valueOf(jwtTokenProvider.extractSubject(accessToken));
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/OAuthResonse.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/oauth/domain/OAuthResonse.java
@@ -1,0 +1,21 @@
+package com.yoonNeun.MyDreamPartner.domain.oauth.domain;
+
+import lombok.Getter;
+
+@Getter
+public class OAuthResonse {
+
+    private final String id;
+    private final String email;
+    private final String name;
+
+    public OAuthResonse(String id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+
+    public static OAuthResonse of(String oauthId, String email, String name) {
+        return new OAuthResonse(oauthId, email, name);
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/application/LoginService.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/application/LoginService.java
@@ -1,0 +1,43 @@
+package com.yoonNeun.MyDreamPartner.domain.user.application;
+
+import com.yoonNeun.MyDreamPartner.domain.oauth.application.OAuthService;
+import com.yoonNeun.MyDreamPartner.domain.oauth.domain.AuthToken;
+import com.yoonNeun.MyDreamPartner.domain.oauth.domain.AuthTokenGenerator;
+import com.yoonNeun.MyDreamPartner.domain.oauth.domain.OAuthResonse;
+import com.yoonNeun.MyDreamPartner.domain.user.domain.User;
+import com.yoonNeun.MyDreamPartner.domain.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LoginService {
+
+    private final OAuthService oAuthService;
+    private final UserRepository userRepository;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    public AuthToken socialLogin(String code, String registrationId) {
+        OAuthResonse oAuthResonse = oAuthService.login(code, registrationId);
+        Integer userId = checkExistingUser(oAuthResonse);
+
+        return authTokenGenerator.generate(userId);
+    }
+
+    private Integer checkExistingUser(OAuthResonse oAuthResonse) {
+        return userRepository.findByEmail(oAuthResonse.getEmail())
+                .map(User::getUserId)
+                .orElseGet(() -> addUser(oAuthResonse));
+    }
+
+    private Integer addUser(OAuthResonse oAuthResonse) {
+        User user = User.builder()
+                .email(oAuthResonse.getEmail())
+                .username(oAuthResonse.getName())
+                .build();
+
+        userRepository.save(user);
+
+        return user.getUserId();
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/application/OAuthService.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/application/OAuthService.java
@@ -76,10 +76,6 @@ public class OAuthService {
         params.add("redirect_uri", redirectUri);
         params.add("grant_type", "authorization_code");
 
-        for (Map.Entry<String, List<String>> entry : params.entrySet()) {
-            System.out.println(entry);
-        }
-
         return params;
     }
 

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/domain/User.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/domain/User.java
@@ -1,0 +1,36 @@
+package com.yoonNeun.MyDreamPartner.domain.user.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer userId;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private UserProfile userProfile;
+
+    @Builder
+    public User(String username, String email) {
+        this.username = username;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/domain/UserProfile.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/domain/UserProfile.java
@@ -1,0 +1,34 @@
+package com.yoonNeun.MyDreamPartner.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user_profiles")
+public class UserProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer userProfileId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String gender;
+    private Long age;
+    private String position;
+
+    @Builder
+    public UserProfile(User user, String gender, Long age, String position) {
+        this.user = user;
+        this.gender = gender;
+        this.age = age;
+        this.position = position;
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/infrastructure/UserRepository.java
@@ -1,0 +1,10 @@
+package com.yoonNeun.MyDreamPartner.domain.user.infrastructure;
+
+import com.yoonNeun.MyDreamPartner.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/presentation/OAuthController.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/user/presentation/OAuthController.java
@@ -1,19 +1,22 @@
 package com.yoonNeun.MyDreamPartner.domain.user.presentation;
 
-import com.yoonNeun.MyDreamPartner.domain.user.application.OAuthService;
+import com.yoonNeun.MyDreamPartner.common.response.SuccessResponse;
+import com.yoonNeun.MyDreamPartner.domain.oauth.domain.AuthToken;
+import com.yoonNeun.MyDreamPartner.domain.user.application.LoginService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping(value = "/login/oauth2", produces = "application/json")
+@Slf4j
 public class OAuthController {
-    OAuthService oAuthService;
-
-    public OAuthController(OAuthService oAuthService) {
-        this.oAuthService = oAuthService;
-    }
+    private final LoginService loginService;
 
     @GetMapping("/code/{registrationId}")
-    public void googleLogin(@RequestParam String code, @PathVariable String registrationId) {
-        oAuthService.socialLogin(code, registrationId);
+    public SuccessResponse<AuthToken> googleLogin(@RequestParam String code, @PathVariable String registrationId) {
+        AuthToken authToken = loginService.socialLogin(code, registrationId);
+        return new SuccessResponse<>(authToken);
     }
 }


### PR DESCRIPTION
## 🔖 Issue
- [x] #6 

## ✏️ Implementation
### (2024.04.20)
- Google OAuth 회원가입 로직을 구현한다.
- jwt 로직을 구현한다.
- Google OAuth 회원가입 관련 Dto를 구현한다.
- 유저 관련 엔티티를 구현한다.

## 🖍️ Question
- 회원가입 로직 구현 중, response 관련 클래스들을 작성하게 되었는데 어떻게 PR을 분리해야할까?

## 🛠️ Refactoring
[ ] 추후, 갱신토큰이 탈취당할 가능성을 줄이기 위해 서버의 redis에 저장하는 로직으로 수정한다.
