### PR TITLE
[#22] 설문 안내 페이지 (난이도 선택 후) 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,5 +214,8 @@ src/main/resources/application.yaml
 # .env
 .env
 
+# query dsl
+src/main/generated
+
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,macos,intellij

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/application/SurveyService.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/application/SurveyService.java
@@ -1,14 +1,12 @@
 package com.yoonNeun.MyDreamPartner.domain.survey.application;
 
 import com.yoonNeun.MyDreamPartner.domain.survey.domain.Survey;
-import com.yoonNeun.MyDreamPartner.domain.survey.infrastructure.SurveyRepository;
+import com.yoonNeun.MyDreamPartner.domain.survey.domain.SurveyDescription;
 import com.yoonNeun.MyDreamPartner.domain.survey.infrastructure.SurveyRepositoryCustomImpl;
-import com.yoonNeun.MyDreamPartner.domain.type.domain.Type;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -17,6 +15,17 @@ public class SurveyService {
     private final SurveyRepositoryCustomImpl surveyRepositoryCustomImpl;
 
     public List<Survey> getSurveyIntroduction() {
-        return surveyRepositoryCustomImpl.findSurveyDetails();
+        return surveyRepositoryCustomImpl.findSurveyIntroductionDetails();
+    }
+
+    public SurveyDescription getSurveyDescription(String type) {
+
+        SurveyDescription surveyDescription = surveyRepositoryCustomImpl.findSurveyDescription(type);
+
+        List<String> categoryNames = surveyRepositoryCustomImpl.findCategoryNamesByType(type);
+
+        List<String> summaries = surveyRepositoryCustomImpl.findSummariesByType(type);
+
+        return new SurveyDescription(surveyDescription.getTypeName(), surveyDescription.getContent(), surveyDescription.getTotalScore(), categoryNames, summaries);
     }
 }

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/domain/SurveyDescription.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/domain/SurveyDescription.java
@@ -1,0 +1,35 @@
+package com.yoonNeun.MyDreamPartner.domain.survey.domain;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SurveyDescription {
+
+    private final String typeName;
+    private final String content;
+    private final Integer totalScore;
+    private final List<String> categoryName;
+    private final List<String> summary;
+
+    public SurveyDescription(String typeName, String content, Integer totalScore, List<String> categoryName, List<String> summary) {
+        this.typeName = typeName;
+        this.content = content;
+        this.totalScore = totalScore;
+        this.categoryName = categoryName;
+        this.summary = summary;
+    }
+
+    public SurveyDescription(String typeName, String content, Integer totalScore) {
+        this.typeName = typeName;
+        this.content = content;
+        this.totalScore = totalScore;
+        this.categoryName = null;
+        this.summary = null;
+    }
+
+    public static SurveyDescription of (String typeName, String content, Integer totalScore, List<String> categoryName, List<String> summary) {
+        return new SurveyDescription(typeName, content, totalScore, categoryName, summary);
+    }
+}

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/infrastructure/SurveyRepositoryCustom.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/infrastructure/SurveyRepositoryCustom.java
@@ -1,9 +1,16 @@
 package com.yoonNeun.MyDreamPartner.domain.survey.infrastructure;
 
 import com.yoonNeun.MyDreamPartner.domain.survey.domain.Survey;
+import com.yoonNeun.MyDreamPartner.domain.survey.domain.SurveyDescription;
 
 import java.util.List;
 
 public interface SurveyRepositoryCustom {
-    List<Survey> findSurveyDetails();
+    List<Survey> findSurveyIntroductionDetails();
+
+    SurveyDescription findSurveyDescription(String type);
+
+    List<String> findCategoryNamesByType(String type);
+
+    List<String> findSummariesByType(String type);
 }

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/infrastructure/SurveyRepositoryCustomImpl.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/infrastructure/SurveyRepositoryCustomImpl.java
@@ -3,12 +3,12 @@ package com.yoonNeun.MyDreamPartner.domain.survey.infrastructure;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yoonNeun.MyDreamPartner.domain.survey.domain.Survey;
+import com.yoonNeun.MyDreamPartner.domain.survey.domain.SurveyDescription;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-// 수동으로 Q class import
 import static com.yoonNeun.MyDreamPartner.domain.type.domain.QType.type;
 import static com.yoonNeun.MyDreamPartner.domain.category.domain.QCategory.category;
 import static com.yoonNeun.MyDreamPartner.domain.typecategory.domain.QTypeCategory.typeCategory;
@@ -20,7 +20,7 @@ public class SurveyRepositoryCustomImpl implements SurveyRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Survey> findSurveyDetails() {
+    public List<Survey> findSurveyIntroductionDetails() {
         return queryFactory
                 .select(Projections.constructor(Survey.class,
                         type.typeName,
@@ -30,6 +30,40 @@ public class SurveyRepositoryCustomImpl implements SurveyRepositoryCustom {
                 .from(typeCategory)
                 .join(typeCategory.type, type)
                 .join(typeCategory.category, category)
+                .fetch();
+    }
+
+    @Override
+    public SurveyDescription findSurveyDescription(String typeName) {
+        return queryFactory
+                .select(Projections.constructor(SurveyDescription.class,
+                        type.typeName,
+                        type.content,
+                        type.totalScore))
+                .from(typeCategory)
+                .join(typeCategory.type, type)
+                .join(typeCategory.category, category)
+                .where(type.typeName.eq(typeName))
+                .fetchFirst();
+    }
+
+    public List<String> findCategoryNamesByType(String typeName) {
+        return queryFactory
+                .select(category.categoryName)
+                .from(typeCategory)
+                .join(typeCategory.category, category)
+                .join(typeCategory.type, type)
+                .where(type.typeName.eq(typeName))
+                .fetch();
+    }
+
+    public List<String> findSummariesByType(String typeName) {
+        return queryFactory
+                .select(category.summary)
+                .from(typeCategory)
+                .join(typeCategory.category, category)
+                .join(typeCategory.type, type)
+                .where(type.typeName.eq(typeName))
                 .fetch();
     }
 }

--- a/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/presentation/SurveyController.java
+++ b/src/main/java/com/yoonNeun/MyDreamPartner/domain/survey/presentation/SurveyController.java
@@ -3,8 +3,11 @@ package com.yoonNeun.MyDreamPartner.domain.survey.presentation;
 import com.yoonNeun.MyDreamPartner.common.response.SuccessResponse;
 import com.yoonNeun.MyDreamPartner.domain.survey.application.SurveyService;
 import com.yoonNeun.MyDreamPartner.domain.survey.domain.Survey;
+import com.yoonNeun.MyDreamPartner.domain.survey.domain.SurveyDescription;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -19,5 +22,11 @@ public class SurveyController {
     public SuccessResponse<List<Survey>> getSurveyIntroduction() {
         List<Survey> surveys = surveyService.getSurveyIntroduction();
         return new SuccessResponse<>(surveys);
+    }
+
+    @GetMapping("/survey/description")
+    public SuccessResponse<SurveyDescription> getSurveyDescription(@RequestParam @NotBlank String type) {
+        SurveyDescription surveyDescription = surveyService.getSurveyDescription(type);
+        return new SuccessResponse<>(surveyDescription);
     }
 }


### PR DESCRIPTION
## 🔖 Issue
- #22 

## ✏️ Implementation
### (2024.06.01)
- [x] 난이도(type - typeName)에 따라 항목(category) 및 관련 데이터가 조회되도록 구현
- [x] 반환되는 응답 데이터 중, 데이터 개수에 따라 별개로 조회하도록 구현
  - (1) 단건 데이터를 조회하는 메서드 (`findSurveyDescription`)
  - (2) 여러 건 데이터를 조회하는 메서드 (`findCategoryNamesByType`, `findSummariesByType`)
  - [x] 이를 위해, 모든 파라미터 (5개)를 받는 생성자 및 단건 데이터 파라미터 (3개)를 받는 생성자 구현

## 🖍️ Question

## 🛠️ Refactoring
